### PR TITLE
Creating js from twig templates

### DIFF
--- a/bin/generate_js_from_templates.php
+++ b/bin/generate_js_from_templates.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Used to create the js from twig template files.
+ * Create a directory named tempates/twig , templates/js, templates/php 
+ * under root folder before you run this script.
+ *
+ * How to run 
+ * php bin/generate_js_from_templates.php
+ *
+ */
+
+require_once __DIR__.'/../tests/bootstrap.php';
+
+if (!isset($_SERVER['TWIG_LIB'])) {
+    throw new \RuntimeException('$_SERVER["TWIG_LIB"] must be set.');
+}
+
+$env = new Twig_Environment();
+$env->setLoader(new Twig_Loader_Filesystem(array(
+    __DIR__.'/../templates/twig',
+)));
+$env->addExtension(new Twig_Extension_Core());
+$handler = new TwigJs\CompileRequestHandler($env, new TwigJs\JsCompiler($env));
+
+foreach (new RecursiveDirectoryIterator(__DIR__.'/../templates/twig', RecursiveDirectoryIterator::SKIP_DOTS) as $file) {
+    if ('.twig' !== substr($file, -5)) {
+        continue;
+    }
+
+    $request = new TwigJs\CompileRequest(basename($file), file_get_contents($file));
+    file_put_contents(__DIR__.'/../templates/js/'.basename($file, '.twig').'.js',
+        $handler->process($request));
+    file_put_contents(__DIR__.'/../templates/php/'.basename($file, '.twig').'.php',
+            $env->compileSource(file_get_contents($file), basename($file)));
+}


### PR DESCRIPTION
Generate js from twig from command line, placing in templates/twig in root and running php bin/generate_js_from_template.php . This will create the js file in templates/js folder ;) . Can be done some more, but this is for now ;)

Want to create a folder named 

```
templates/twig 
templates/js
templates/php
```

 Keeping the templates in twig folder and executing will create a js . For the current time I have not created any interactive ones. But just copied and made some adjustments for the generating test templates file.
