### PR TITLE
Fix array compiler so that it compiles JavaScript object arrays correctl...

### DIFF
--- a/src/TwigJs/Compiler/Expression/ArrayCompiler.php
+++ b/src/TwigJs/Compiler/Expression/ArrayCompiler.php
@@ -36,19 +36,37 @@ class ArrayCompiler implements TypeCompilerInterface
 
         // FIXME: Should real JS arrays be supported, i.e. numeric PHP arrays?
         $compiler->raw('{');
+
         $first = true;
-        foreach ($node as $name => $subNode) {
+
+        foreach ($this->getKeyValuePairs($node) as $pair) {
             if (!$first) {
                 $compiler->raw(', ');
             }
+
             $first = false;
 
             $compiler
-                ->repr($name)
+                ->subcompile($pair['key'])
                 ->raw(': ')
-                ->subcompile($subNode)
+                ->subcompile($pair['value'])
             ;
         }
+
         $compiler->raw('}');
+    }
+
+    private function getKeyValuePairs(\Twig_Node $node)
+    {
+        $pairs = array();
+
+        foreach (array_chunk($node->getIterator()->getArrayCopy(), 2) as $pair) {
+            $pairs[] = array(
+                'key'   => $pair[0],
+                'value' => $pair[1],
+            );
+        }
+
+        return $pairs;
     }
 }


### PR DESCRIPTION
...y

OK obviously we've got no tests for this, so it will be hard for you to want to merge this, however after the fix, templates are generated more correctly.

Before:

``` js
context["attr"] = twig.filter.merge("attr" in context ? context["attr"] : null, {
    0: "class",
    1: (((twig.attr(twig.filter.def("attr" in context ? context["attr"] : null), "class", undefined, undefined, true)) ? (twig.filter.def(twig.attr("attr" in context ? context["attr"] : null, "class"), "")) : ("")) + " required")
});
```

After:

``` js
context["attr"] = twig.filter.merge("attr" in context ? context["attr"] : null, {
    "class": (((twig.attr(twig.filter.def("attr" in context ? context["attr"] : null), "class", undefined, undefined, true)) ? (twig.filter.def(twig.attr("attr" in context ? context["attr"] : null, "class"), "")) : ("")) + " required")
});
```
