### PR TITLE
Implements #20 fix

### DIFF
--- a/src/TwigJs/Assetic/TwigJsFilter.php
+++ b/src/TwigJs/Assetic/TwigJsFilter.php
@@ -48,4 +48,8 @@ class TwigJsFilter implements FilterInterface
     public function filterLoad(AssetInterface $asset)
     {
     }
+
+    public function __sleep() {
+        return array();
+    }
 }


### PR DESCRIPTION
When using assetic use_controller it tries to generate a cache key by serializing the filter. TwigJsFilter contains a reference to CompileRequestHandler so it tries to serialize that object and fails.

This line -> https://github.com/kriswallsmith/assetic/blob/v1.0.3/src/Assetic/Asset/AssetCache.php#L138 is called only when using use_controller and it makes the process fail.
