### PR TITLE
Adds HashableInterface to the TwigJsFilter to avoid the assetCache bug.

### DIFF
--- a/src/TwigJs/Assetic/TwigJsFilter.php
+++ b/src/TwigJs/Assetic/TwigJsFilter.php
@@ -50,7 +50,7 @@ class TwigJsFilter implements FilterInterface, HashableInterface
     {
     }
 
-    function hash()
+    public function hash()
     {
         return 'twigjsfilter';
     }


### PR DESCRIPTION
Fixes #20 and it's child of #28. But it depends on https://github.com/kriswallsmith/assetic/pull/228
