### PR TITLE
fixes JsCompiler to work with twig 1.6.4+

### DIFF
--- a/src/TwigJs/JsCompiler.php
+++ b/src/TwigJs/JsCompiler.php
@@ -308,6 +308,8 @@ class JsCompiler extends \Twig_Compiler
     {
         $this->lastLine = null;
         $this->source = '';
+        $this->sourceOffset = 0;
+        $this->sourceLine = 0;
         $this->indentation = $indentation;
 
         $this->subcompile($node);


### PR DESCRIPTION
This commit https://github.com/fabpot/Twig/commit/27f55cc5673e41d471cffdb26d385a2990b134dc introduced the problem.
When compiling more than one twig in a row it breaks (in symfony it can be reproduced with app/console cache:warmup --env=prod) because the sourceOffset is not re inialized to 0
