### PR TITLE
Fixing up the macro compiler to be inline with twigs behaviour

### DIFF
--- a/src/TwigJs/Compiler/MacroCompiler.php
+++ b/src/TwigJs/Compiler/MacroCompiler.php
@@ -37,11 +37,13 @@ class MacroCompiler implements TypeCompilerInterface
         $compiler->enterScope();
 
         $arguments = array();
+        $contextVars = array();
         foreach ($node->getNode('arguments') as $argument) {
             $name = $argument->getAttribute('name');
-
-            $arguments[] = 'opt_'.$name;
-            $compiler->setVar($name, 'opt_'.$name);
+            $opt_name = 'opt_'.$name;
+            $arguments[] = $opt_name;
+            $compiler->setVar($name, $opt_name);
+            $contextVars[] = $name . ":" . $opt_name;
         }
 
         $compiler
@@ -61,7 +63,7 @@ class MacroCompiler implements TypeCompilerInterface
             ->raw($node->getAttribute('name'))
             ->raw(" = function(".implode(', ', $arguments).") {\n")
             ->indent()
-            ->write("var context = twig.extend({}, this.env_.getGlobals());\n\n")
+            ->write("var context = twig.extend({". implode(",",$contextVars)  ."}, this.env_.getGlobals());\n\n")
             ->write("var sb = new twig.StringBuffer;\n")
             ->subcompile($node->getNode('body'))
             ->raw("\n")


### PR DESCRIPTION
The macro compiler does not copy the arguments into the context currently. This is the behaviour that twig exposes as seen in the out put from this compiled function.

```
  $context = $this->env->mergeGlobals(array(
        "pager" => $pager,
        "url" => $url,
    ));
```

This pull request does just that :)
