### PR TITLE
Added the ability to create JS function compilers

### DIFF
--- a/src/TwigJs/Compiler/Expression/FunctionCompiler.php
+++ b/src/TwigJs/Compiler/Expression/FunctionCompiler.php
@@ -39,12 +39,13 @@ class FunctionCompiler implements TypeCompilerInterface
             throw new \Twig_Error_Syntax(sprintf('The function "%s" does not exist', $node->getAttribute('name')), $node->getLine());
         }
 
-        if ($compiler->hasFunctionCompiler($node->getAttribute('name'))) {
+        if ($functionCompiler = $compiler->getFunctionCompiler($node)) {
+
             // Let the function compiler completely handle compilation and alter
             // the method signature as it requires.
-            $functionCompiler = $compiler->getFunctionCompiler($node->getAttribute('name'));
             $functionCompiler->compile($compiler, $node);
             return;
+
         } elseif ($jsFunction = $compiler->getJsFunction($node->getAttribute('name'))) {
             $compiler->raw($jsFunction.'(');
         } else {

--- a/src/TwigJs/FunctionCompilerInterface.php
+++ b/src/TwigJs/FunctionCompilerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2013 Josiah <josiah@jjs.id.au>
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,19 @@ use Twig_Node_Expression_Function;
  */
 interface FunctionCompilerInterface
 {
+    /**
+     * Indicates whether this function compiler is able to compile the specified
+     * function node.
+     *
+     * This allows function compilers to 'opt-out' of node compilation if
+     * they're not able to satisfy something which has been defined in the
+     * function node.
+     * 
+     * @param Twig_Node_Expression_Function $node Node for compilation
+     * @return boolean TRUE if the node can be compiled; FALSE otherwise.
+     */
+    function canCompile(Twig_Node_Expression_Function $node);
+
     /**
      * Compiles a twig function for use in javascript and compiles a method call
      * appropriate for the specified node.


### PR DESCRIPTION
Added the ability to create a function compiler which overrides the normal compilation process for a twig function when its compiled for javascript.

This patch is required for the changes in [issue 22](https://github.com/schmittjoh/JMSTwigJsBundle/issues/22) of the [JMSTwigJSBundle](https://github.com/schmittjoh/JMSTwigJsBundle).
