### PR TITLE
GetAttrCompiler produces redundant macros arguments during macros call compilation

### DIFF
--- a/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
+++ b/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
@@ -57,21 +57,7 @@ class GetAttrCompiler implements TypeCompilerInterface
         $defaultTest = false == $node->getAttribute('is_defined_test');
 
         if (!$defaultArguments) {
-            $compiler->raw(', [');
-
-            $first = true;
-            foreach ($node->getNode('arguments') as $argNode) {
-                if (!$first) {
-                    $compiler->raw(', ');
-                }
-                $first = false;
-
-                $compiler
-                    ->subcompile($argNode)
-                ;
-            }
-
-            $compiler->raw(']');
+            $compiler->raw(', ')->subcompile($node->getNode('arguments'));
         } else if (!$defaultAccess || !$defaultTest) {
             $compiler->raw(', undefined');
         }


### PR DESCRIPTION
Hello @schmittjoh!

Probably there is an issue with compiling twig macros calls with parameters.

That's my case below.
I am using two twig templates in symfony 2 application.
The first one contains **show** macro definition and looks like this:

``` twig
{% twig_js name="twig.compiled.flags" %}
{% macro show(country) %}
    <div class="flag_{{ country }}"></div>
{% endmacro %}
```

The second one includes **show** macro and invokes it with 2 parameters:

``` twig
{% twig_js name="twig.compiled.flags_temp" %}
{% import "::blocks/flags/flags.html.twig" as flags %}

{{ flags.show(country) }}
```

After compilation i am trying to call the second template from javascript like this:

``` javascript
Twig.render(twig.compiled.flags_temp, {country: "fr"})
```

The expected result is:

``` javascript
<div class="flag flag_fr"></div>
```

But actual result looks like this:

``` javascript
<div class="flag flag_0"></div>
```

Attempting to understand the problem i've analyzed compiled representation of my both original twig templates. The second one has redundant argument **0** in **show** parameter list, therefore original macro did not work as expected:

``` javascript
/**
 * @inheritDoc
 */
twig.compiled.flags_temp.prototype.render_ = function(sb, context, blocks) {
    // line 2
    context["flags"] = this.env_.createTemplate(twig.compiled.flags);
    // line 3
    sb.append("\n");
    // line 4
    sb.append(twig.attr("flags" in context ? context["flags"] : null, "show", [0, "country" in context ? context["country"] : null], "method"));
};
```

The cause of this is clear to me: twig parser fills macro parameters into [Twig_Node_Expression_Array](https://github.com/fabpot/Twig/blob/master/lib/Twig/Node/Expression/Array.php) object using its [addElement](https://github.com/fabpot/Twig/blob/master/lib/Twig/Node/Expression/Array.php#L54-L61) method that prepends each element with new constant node that contains index of element (excluding associative arrays case with it predefined keys). 
And then twig-js's [GetAttrCompiler](https://github.com/schmittjoh/twig.js/blob/master/src/TwigJs/Compiler/Expression/GetAttrCompiler.php) compiles **all** the parameters (including generated index-elements) provided by parser into js function arguments here: [https://github.com/schmittjoh/twig.js/blob/master/src/TwigJs/Compiler/Expression/GetAttrCompiler.php#L60-L74](https://github.com/schmittjoh/twig.js/blob/master/src/TwigJs/Compiler/Expression/GetAttrCompiler.php#L60-L74) and it causes extra parameters appearance. 

What if we'll use [ArrayCompiler](https://github.com/schmittjoh/twig.js/blob/master/src/TwigJs/Compiler/Expression/ArrayCompiler.php) to compile getattr arguments? In this case we would manage flexibly argument sets as key-values and get only needed values in getattr arguments lists.
