### PR TITLE
Brackets for sameas test to pass test negation

### DIFF
--- a/src/TwigJs/Compiler/Test/SameAsCompiler.php
+++ b/src/TwigJs/Compiler/Test/SameAsCompiler.php
@@ -15,9 +15,10 @@ class SameAsCompiler implements TestCompilerInterface
     public function compile(JsCompiler $compiler, \Twig_Node_Expression_Test $node)
     {
         $compiler
+            ->raw('(')
             ->subcompile($node->getNode('node'))
             ->raw(' === ')
             ->subcompile($node->getNode('arguments')->getNode(0))
-        ;
+            ->raw(')');
     }
 }

--- a/tests/TwigJs/Tests/Fixture/generated/sameas.js
+++ b/tests/TwigJs/Tests/Fixture/generated/sameas.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Compiled template for file
+ *
+ * Tests/Fixture/templates/sameas.twig
+ *
+ * @suppress {checkTypes|fileoverviewTags}
+ */
+
+goog.provide('sameas');
+
+goog.require('twig');
+goog.require('twig.filter');
+
+/**
+ * @constructor
+ * @param {twig.Environment} env
+ * @extends {twig.Template}
+ */
+sameas = function(env) {
+    twig.Template.call(this, env);
+};
+twig.inherits(sameas, twig.Template);
+
+/**
+ * @inheritDoc
+ */
+sameas.prototype.getParent_ = function(context) {
+    return false;
+};
+
+/**
+ * @inheritDoc
+ */
+sameas.prototype.render_ = function(sb, context, blocks) {
+    // line 1
+    sb.append("This is a simple template.<br \/><br \/>\n\n");
+    // line 3
+    if ((!(("name" in context ? context["name"] : null) === false))) {
+        // line 4
+        sb.append("Hello not false!\n");
+    }
+};
+
+/**
+ * @inheritDoc
+ */
+sameas.prototype.getTemplateName = function() {
+    return "sameas";
+};
+
+/**
+ * Returns whether this template can be used as trait.
+ *
+ * @return {boolean}
+ */
+sameas.prototype.isTraitable = function() {
+    return false;
+};

--- a/tests/TwigJs/Tests/Fixture/generated/simple_standalone.js
+++ b/tests/TwigJs/Tests/Fixture/generated/simple_standalone.js
@@ -38,8 +38,7 @@ simple_standalone.prototype.render_ = function(sb, context, blocks) {
     if (("name" in context)) {
         // line 4
         sb.append("Hello ");
-        var tmp_name = ("name" in context) ? context["name"] : null;
-        sb.append(twig.filter.escape(this.env_, twig.filter.capitalize(this.env_, tmp_name), "html", null, true));
+        sb.append(twig.filter.escape(this.env_, twig.filter.capitalize(this.env_, ("name" in context ? context["name"] : null)), "html", null, true));
         sb.append("!\n");
     } else {
         // line 6

--- a/tests/TwigJs/Tests/Fixture/templates/sameas.twig
+++ b/tests/TwigJs/Tests/Fixture/templates/sameas.twig
@@ -1,0 +1,5 @@
+This is a simple template.<br /><br />
+
+{% if name is not sameas(false) %}
+Hello not false!
+{% endif %}


### PR DESCRIPTION
Twig code for sameas test 

``` twig
{% if name is not sameas(false) %}
    Hello not false!
{% endif %}
```

compiles with twig.js into 

``` javascript
if ((!("name" in context ? context["name"] : null) === false)) {
    sb.append("Hello not false!\n");
}
```

so, the first expression negation

``` javascript
!("name" in context ? context["name"] : null)
```

is compared to false. But in twig i have the negation of sameas(false). And i get !0 === false, that gives false, and should get !(0 === false) and true as a result.
So i want to get 

``` javascript
if ((!(("name" in context ? context["name"] : null) === false))) {
    sb.append("Hello not false!\n");
}
```

to negate the entire expression.
