### PR TITLE
Change the scope of ModuleCompiler->functionName to protected.

### DIFF
--- a/src/TwigJs/Compiler/ModuleCompiler.php
+++ b/src/TwigJs/Compiler/ModuleCompiler.php
@@ -23,7 +23,7 @@ use TwigJs\TypeCompilerInterface;
 
 class ModuleCompiler implements TypeCompilerInterface
 {
-    private $functionName;
+    protected $functionName;
     private $constantParent;
 
     public function getType()


### PR DESCRIPTION
Hi.

This PR is related to https://github.com/schmittjoh/JMSTwigJsBundle/issues/25.
To be able to output AMD compatible templates, I extended the `ModuleCompiler` (see https://github.com/kimlai/melikeyradio/blob/master/src/MeLikey/WebAppBundle/TwigJs/Compiler/AmdModuleCompiler.php), but to do so I need to access the `functionName` property in the child
class.

I couldn't come up with a way around this change for me to get require-js compatible templates.
