### PR TITLE
Ignore profiler nodes

### DIFF
--- a/src/TwigJs/JsCompiler.php
+++ b/src/TwigJs/JsCompiler.php
@@ -332,6 +332,10 @@ class JsCompiler extends \Twig_Compiler
 
     public function subcompile(\Twig_NodeInterface $node, $raw = true)
     {
+        if ($node instanceof \Twig_Profiler_Node_EnterProfile || $node instanceof \Twig_Profiler_Node_LeaveProfile) {
+            return $this;
+        }
+
         if (false === $raw) {
             $this->addIndentation();
         }


### PR DESCRIPTION
In dev environment, twig >=1.18 injects special nodes in blocks and macros for profiling. As those nodes are not supported by the js compiler (that wouldn't make sense anyway), it's no longer possible to compile twigjs templates containing blocks or macros in dev mode. This PR just makes the compiler ignore the profiler nodes when it encounters them.