### PR TITLE
Allow inclusion of variable template names

### DIFF
--- a/src/TwigJs/Compiler/IncludeCompiler.php
+++ b/src/TwigJs/Compiler/IncludeCompiler.php
@@ -50,7 +50,13 @@ class IncludeCompiler implements TypeCompilerInterface
 //         }
 
         $compiler->isTemplateName = true;
-        if ($node->getNode('expr') instanceof Twig_Node_Expression_Constant) {
+        if ($node->getNode('expr') instanceof \Twig_Node_Expression_Name) {
+            $compiler
+                ->write("(new (eval(")
+                ->subcompile($node->getNode('expr'))
+                ->raw(".replace(\".twig\", \"\")))(this.env_)).render_(sb, ")
+            ;
+        } elseif ($node->getNode('expr') instanceof Twig_Node_Expression_Constant) {
             $compiler
                 ->write("(new ")
                 ->subcompile($node->getNode('expr'))

--- a/tests/TwigJs/Tests/Fixture/integration/functions/include/include_variable_template_name.test
+++ b/tests/TwigJs/Tests/Fixture/integration/functions/include/include_variable_template_name.test
@@ -1,0 +1,18 @@
+--TEST--
+"include " function
+--TEMPLATE(foo_template)--
+FOOBAR
+--TEMPLATE--
+FOO
+{% set foo = "foo_template.twig" %}
+{% include(foo) %}
+
+BAR
+--DATA--
+return {}
+--EXPECT--
+FOO
+
+FOOBAR
+
+BAR


### PR DESCRIPTION
Hello,

I have two issues with this PR:

* `eval`
* AMD compiler - @hnrysmth you mentioned that this approach won't work for this compiler?

The quick hack from https://github.com/schmittjoh/twig.js/issues/77 used `window[variable]` but I could not get the integration test to work with that approach.