### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ php:
   - 5.3
   - 5.6
   - 7.0
+sudo: false
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: php
 php:
   - 5.3
+  - 5.6
+  - 7.0
 script: make test


### PR DESCRIPTION
- run tests on more recent versions of PHP (5.6, 7.0), because people care about these version too
- run tests on new container infrastructure, because
  - recommended by Travis - see https://docs.travis-ci.com/user/migrating-from-legacy/)
  - ![image](https://cloud.githubusercontent.com/assets/5679032/18171839/a160faf6-7063-11e6-80c1-f3df718e78b2.png)
