### PR TITLE
Fixes for twig v1.25

### DIFF
--- a/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
+++ b/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
@@ -57,7 +57,7 @@ class GetAttrCompiler implements TypeCompilerInterface
             ->subcompile($node->getNode('attribute'))
         ;
 
-        $defaultArguments = 0 === count($node->getNode('arguments'));
+        $defaultArguments = 0 === count(($node->hasNode('arguments') ? $node->getNode('arguments') : null));
         $defaultAccess = \Twig_TemplateInterface::ANY_CALL === $node->getAttribute('type');
         $defaultTest = false == $node->getAttribute('is_defined_test');
 

--- a/src/TwigJs/Compiler/Expression/Test/DefinedCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/DefinedCompiler.php
@@ -27,7 +27,7 @@ class DefinedCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                ($node->hasNode('arguments') ? $node->getNode('arguments') : null),
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/EvenCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/EvenCompiler.php
@@ -27,7 +27,7 @@ class EvenCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                ($node->hasNode('arguments') ? $node->getNode('arguments') : null),
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
@@ -27,7 +27,7 @@ class NullCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                ($node->hasNode('arguments') ? $node->getNode('arguments') : null),
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/ForCompiler.php
+++ b/src/TwigJs/Compiler/ForCompiler.php
@@ -73,7 +73,7 @@ class ForCompiler implements TypeCompilerInterface
             ->raw(";\n")
         ;
 
-        if (null !== $node->getNode('else')) {
+        if (null !== ($node->hasNode('else') ? $node->getNode('else') : null)) {
             $compiler->write("var $iteratedName = false;\n");
         }
 
@@ -117,7 +117,7 @@ class ForCompiler implements TypeCompilerInterface
         $ref = new \ReflectionProperty($node, 'loop');
         $ref->setAccessible(true);
         $loop = $ref->getValue($node);
-        $loop->setAttribute('else', null !== $node->getNode('else'));
+        $loop->setAttribute('else', null !== ($node->hasNode('else') ? $node->getNode('else') : null));
         $loop->setAttribute('with_loop', $node->getAttribute('with_loop'));
         $loop->setAttribute('ifexpr', $node->getAttribute('ifexpr'));
 
@@ -135,7 +135,7 @@ class ForCompiler implements TypeCompilerInterface
             ->write("}, this);\n")
         ;
 
-        if (null !== $node->getNode('else')) {
+        if (null !== ($node->hasNode('else') ? $node->getNode('else') : null)) {
             $compiler
                 ->write("if (!$iteratedName) {\n")
                 ->indent()

--- a/src/TwigJs/Compiler/IncludeCompiler.php
+++ b/src/TwigJs/Compiler/IncludeCompiler.php
@@ -66,7 +66,7 @@ class IncludeCompiler implements TypeCompilerInterface
         $compiler->isTemplateName = false;
 
         if (false === $node->getAttribute('only')) {
-            if (null === $node->getNode('variables')) {
+            if (null === ($node->hasNode('variables') ? $node->getNode('variables') : null)) {
                 $compiler->raw('context');
             } else {
                 $compiler

--- a/src/TwigJs/Compiler/ModuleCompiler.php
+++ b/src/TwigJs/Compiler/ModuleCompiler.php
@@ -57,7 +57,7 @@ abstract class ModuleCompiler
             ->write('return ')
         ;
 
-        if (null === $node->getNode('parent')) {
+        if (null === ($node->hasNode('parent') ? $node->getNode('parent') : null)) {
             $compiler->repr(false);
         } else {
             $compiler
@@ -82,7 +82,7 @@ abstract class ModuleCompiler
             ->leaveScope()
         ;
 
-        if (null !== $node->getNode('parent')) {
+        if (null !== ($node->hasNode('parent') ? $node->getNode('parent') : null)) {
             $compiler
                 ->write("this.getParent(context).render_(sb, context, twig.extend({}, this.getBlocks(), blocks));\n")
             ;
@@ -228,7 +228,7 @@ abstract class ModuleCompiler
         //
         // Put another way, a template can be used as a trait if it
         // only contains blocks and use statements.
-        $traitable = null === $node->getNode('parent') && 0 === count($node->getNode('macros'));
+        $traitable = null === ($node->hasNode('parent') ? $node->getNode('parent') : null) && 0 === count($node->getNode('macros'));
         if ($traitable) {
             if (!count($nodes = $node->getNode('body'))) {
                 $nodes = new Twig_Node(array($node->getNode('body')));


### PR DESCRIPTION
This fixes #107.
Twig.js in conjunction with twig v1.25+ throws an exception when trying to call Twig_Node::getNode() for non existent child nodes. This PR adds checks before calling the getNode method.